### PR TITLE
Set LangVersion and annotate #nullable to avoid build errors and warnings

### DIFF
--- a/BetterStack.Logs.Serilog.csproj
+++ b/BetterStack.Logs.Serilog.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);example-project/**;dashboard.png</DefaultItemExcludes>
   </PropertyGroup>

--- a/BetterStack.Logs.Serilog/BetterStackHttpClient.cs
+++ b/BetterStack.Logs.Serilog/BetterStackHttpClient.cs
@@ -40,7 +40,7 @@ namespace BetterStack.Logs.Serilog
         /// <inheritdoc />
         public virtual async Task<HttpResponseMessage> PostAsync(string requestUri, Stream contentStream)
         {
-            using var content = new StreamContent(contentStream);
+            var content = new StreamContent(contentStream);
             content.Headers.Add("Content-Type", "application/json");
 
             var response = await httpClient

--- a/BetterStack.Logs.Serilog/LoggerSinkConfigurationExtensions.cs
+++ b/BetterStack.Logs.Serilog/LoggerSinkConfigurationExtensions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using BetterStack.Logs.Serilog;
 using Serilog.Configuration;
 using Serilog.Core;


### PR DESCRIPTION
Ran into issues when building the package:

Error:

```
./BetterStack.Logs.Serilog/LoggerSinkConfigurationExtensions.cs(52,31): error CS8370:
Feature 'nullable reference types' is not available in C# 7.3. Please use language version 8.0 or greater.
[./BetterStack.Logs.Serilog.csproj::TargetFramework=netstandard2.0]
```

---

Warning:

```
./BetterStack.Logs.Serilog/LoggerSinkConfigurationExtensions.cs(52,31): warning CS8632:
The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
[./BetterStack.Logs.Serilog.csproj::TargetFramework=netstandard2.1]
```