### PR TITLE
Upgrade to Serilog.Sinks.Http 9.0.0

### DIFF
--- a/BetterStack.Logs.Serilog.csproj
+++ b/BetterStack.Logs.Serilog.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>BetterStack.Logs.Serilog</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Simon Rozsival, Tomas Hromada</Authors>
     <Company>Better Stack</Company>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/BetterStack.Logs.Serilog.csproj
+++ b/BetterStack.Logs.Serilog.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Http" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BetterStack.Logs.Serilog/BetterStackHttpClient.cs
+++ b/BetterStack.Logs.Serilog/BetterStackHttpClient.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http.Headers;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Threading;
 using System;
 
 namespace BetterStack.Logs.Serilog
@@ -40,11 +41,17 @@ namespace BetterStack.Logs.Serilog
         /// <inheritdoc />
         public virtual async Task<HttpResponseMessage> PostAsync(string requestUri, Stream contentStream)
         {
-            var content = new StreamContent(contentStream);
-            content.Headers.Add("Content-Type", "application/json");
+            return await PostAsync(requestUri, contentStream, CancellationToken.None);
+        }
+
+        /// <inheritdoc />
+        public virtual async Task<HttpResponseMessage> PostAsync(string requestUri, Stream contentStream, CancellationToken cancellationToken)
+        {
+            using var content = new StreamContent(contentStream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             var response = await httpClient
-                .PostAsync(requestUri, content)
+                .PostAsync(requestUri, content, cancellationToken)
                 .ConfigureAwait(false);
 
             return response;

--- a/BetterStack.Logs.Serilog/LoggerSinkConfigurationExtensions.cs
+++ b/BetterStack.Logs.Serilog/LoggerSinkConfigurationExtensions.cs
@@ -65,6 +65,7 @@ namespace Serilog
                 logEventsInBatchLimit: batchSize,
                 batchSizeLimitBytes: null,
                 period: batchInterval.Value,
+                flushOnClose: true,
                 textFormatter: new BetterStackTextFormatter(),
                 batchFormatter: new ArrayBatchFormatter(),
                 httpClient: new BetterStackHttpClient(sourceToken));


### PR DESCRIPTION
Resolves https://github.com/BetterStackHQ/logs-client-serilog/issues/5

This ensures compatibility with the breaking changes in [Serilog.Sinks.Http 9.0.0](https://github.com/FantasticFiasco/serilog-sinks-http/releases/tag/v9.0.0).

I've tried to come up with a solution compatible with both versions, but I couldn't find anything easy to use. I could use reflection, which would make this project harder to understand and maintain with a bit of performance reduction. I could use conditional compilation, but there's no way to detect the used package version, so users would still need to manually switch the version using constants.

In the end, I think just upgrading is a cleaner solution. I would love to get some feedback on this.