### PR TITLE
Update used versions in example project

### DIFF
--- a/example-project/ExampleProject.csproj
+++ b/example-project/ExampleProject.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BetterStack.Logs.Serilog" Version="1.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="BetterStack.Logs.Serilog" Version="1.1.*" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Just updating versions in example project to the latest ones. Verified to work.

As a side note, the example also works with the previously used versions and `BetterStack.Logs.Serilog` in `v1.1.0`.

Adding asterisks to always use the latest patches in our example project.